### PR TITLE
Add the mailbox subsystem

### DIFF
--- a/simgui-ds.json
+++ b/simgui-ds.json
@@ -4,6 +4,11 @@
       "visible": true
     }
   },
+  "System Joysticks": {
+    "window": {
+      "enabled": false
+    }
+  },
   "keyboardJoysticks": [
     {
       "axisConfig": [
@@ -95,6 +100,7 @@
     }
   ],
   "robotJoysticks": [
+    {},
     {
       "guid": "Keyboard0"
     }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -9,7 +9,7 @@ import frc.robot.commands.mailbox.OutputCommand;
 import frc.robot.commands.mailbox.StopCommand;
 import frc.robot.constants.RobotContainerConstants;
 import frc.robot.subsystems.gyro.GyroSubsystem;
-import frc.robot.subsystems.mailbox.MailboxSubststem;
+import frc.robot.subsystems.mailbox.MailboxSubsystem;
 import frc.robot.subsystems.elevator.ElevatorSubsystem;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -37,7 +37,7 @@ public class RobotContainer {
   public static final GyroSubsystem gyroSubsystem = new GyroSubsystem();
   public static final ElevatorSubsystem elevatorSubsystem = new ElevatorSubsystem(RobotContainerConstants.ELEVATOR_PRIMARY_MOTOR_ID,
                                                                                   RobotContainerConstants.ELEVATOR_SECONDARY_MOTOR_ID);
-  public static final MailboxSubststem mailboxSubsystem = new MailboxSubststem();
+  public static final MailboxSubsystem mailboxSubsystem = new MailboxSubsystem();
 
   /** The container for the robot. Contains subsystems, OI devices, and commands. */
   public RobotContainer() {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -4,11 +4,17 @@
 
 package frc.robot;
 
+import frc.robot.commands.mailbox.InputCommand;
+import frc.robot.commands.mailbox.OutputCommand;
+import frc.robot.commands.mailbox.StopCommand;
 import frc.robot.constants.RobotContainerConstants;
 import frc.robot.subsystems.gyro.GyroSubsystem;
+import frc.robot.subsystems.mailbox.MailboxSubststem;
 import frc.robot.subsystems.elevator.ElevatorSubsystem;
+import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
+import edu.wpi.first.wpilibj2.command.button.JoystickButton;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
 
 /**
@@ -19,12 +25,19 @@ import edu.wpi.first.wpilibj2.command.button.Trigger;
  */
 public class RobotContainer {
   // Controllers
-  private final CommandXboxController driverController = new CommandXboxController(RobotContainerConstants.DRIVER_CONTROLLER_PORT);
+  private final XboxController driverController   = new XboxController(RobotContainerConstants.DRIVER_CONTROLLER_PORT);
+  private final XboxController operatorController = new XboxController(RobotContainerConstants.OPERATOR_CONTROLLER_PORT);
+
+  // Controller buttons
+  private final JoystickButton mailboxInputButton  = new JoystickButton(operatorController, RobotContainerConstants.MAILBOX_INPUT_BUTTON);
+  private final JoystickButton mailboxOutputButton = new JoystickButton(operatorController, RobotContainerConstants.MAILBOX_OUTPUT_BUTTON);
+  private final JoystickButton mailboxStopButton   = new JoystickButton(operatorController, RobotContainerConstants.MAILBOX_STOP_BUTTON);
 
   // Subsystems
   public static final GyroSubsystem gyroSubsystem = new GyroSubsystem();
   public static final ElevatorSubsystem elevatorSubsystem = new ElevatorSubsystem(RobotContainerConstants.ELEVATOR_PRIMARY_MOTOR_ID,
                                                                                   RobotContainerConstants.ELEVATOR_SECONDARY_MOTOR_ID);
+  public static final MailboxSubststem mailboxSubsystem = new MailboxSubststem();
 
   /** The container for the robot. Contains subsystems, OI devices, and commands. */
   public RobotContainer() {
@@ -42,7 +55,9 @@ public class RobotContainer {
    * joysticks}.
    */
   private void configureBindings() {
-    
+    mailboxInputButton.onTrue(new InputCommand());
+    mailboxOutputButton.onTrue(new OutputCommand());
+    mailboxStopButton.onTrue(new StopCommand());
   }
 
   /**

--- a/src/main/java/frc/robot/XboxMappings.java
+++ b/src/main/java/frc/robot/XboxMappings.java
@@ -1,0 +1,36 @@
+package frc.robot;
+
+public class XboxMappings {
+    public class Button {
+        public static final int A = 1;
+        public static final int B = 2;
+        public static final int X = 3;
+        public static final int Y = 4;
+        public static final int LeftBumper = 5;
+        public static final int RightBumper = 6;
+        public static final int Back = 7;
+        public static final int Start = 8;
+        public static final int LeftStick = 9;
+        public static final int RightStick = 10;
+    }
+    
+    public class Axis {
+        public static final int LeftStickX = 0;
+        public static final int LeftStickY = 1;
+        public static final int LeftTrigger = 2;
+        public static final int RightTrigger = 3;
+        public static final int RightStickX = 4;
+        public static final int RightStickY = 5;
+    }
+
+    public class DPad {
+        public static final int Up = 0;
+        public static final int UpRIght = 45;
+        public static final int Right = 90;
+        public static final int DownRight = 135;
+        public static final int Down = 180;
+        public static final int DownLeft = 225;
+        public static final int Left = 270;
+        public static final int UpLeft = 315;
+    }
+}

--- a/src/main/java/frc/robot/commands/mailbox/InputCommand.java
+++ b/src/main/java/frc/robot/commands/mailbox/InputCommand.java
@@ -1,0 +1,20 @@
+package frc.robot.commands.mailbox;
+
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.RobotContainer;
+
+public class InputCommand extends Command {
+    public InputCommand() {
+        addRequirements(RobotContainer.mailboxSubsystem);
+    }
+    
+    @Override
+    public void initialize() {
+        RobotContainer.mailboxSubsystem.input();
+    }
+    
+    @Override
+    public boolean isFinished() {
+        return true;
+    }
+}

--- a/src/main/java/frc/robot/commands/mailbox/OutputCommand.java
+++ b/src/main/java/frc/robot/commands/mailbox/OutputCommand.java
@@ -1,0 +1,20 @@
+package frc.robot.commands.mailbox;
+
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.RobotContainer;
+
+public class OutputCommand extends Command {
+    public OutputCommand() {
+        addRequirements(RobotContainer.mailboxSubsystem);
+    }
+    
+    @Override
+    public void initialize() {
+        RobotContainer.mailboxSubsystem.output();
+    }
+    
+    @Override
+    public boolean isFinished() {
+        return true;
+    }
+}

--- a/src/main/java/frc/robot/commands/mailbox/StopCommand.java
+++ b/src/main/java/frc/robot/commands/mailbox/StopCommand.java
@@ -1,0 +1,20 @@
+package frc.robot.commands.mailbox;
+
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.RobotContainer;
+
+public class StopCommand extends Command {
+    public StopCommand() {
+        addRequirements(RobotContainer.mailboxSubsystem);
+    }
+    
+    @Override
+    public void initialize() {
+        RobotContainer.mailboxSubsystem.stop();
+    }
+    
+    @Override
+    public boolean isFinished() {
+        return true;
+    }
+}

--- a/src/main/java/frc/robot/constants/MailboxConstants.java
+++ b/src/main/java/frc/robot/constants/MailboxConstants.java
@@ -1,0 +1,10 @@
+package frc.robot.constants;
+
+public class MailboxConstants {
+    public static final int MOTOR_ONE_ID = 1;
+    public static final int MOTOR_TWO_ID = 2;
+
+    public static final double OUTPUT_MOTOR_SPEED = 1;
+    public static final double INPUT_MOTOR_ONE_SPEED = 1;
+    public static final double INPUT_MOTOR_TWO_SPEED = -0.2;
+}

--- a/src/main/java/frc/robot/constants/RobotContainerConstants.java
+++ b/src/main/java/frc/robot/constants/RobotContainerConstants.java
@@ -1,7 +1,15 @@
 package frc.robot.constants;
 
+import frc.robot.XboxMappings;
+
 public class RobotContainerConstants {
-    public static final int DRIVER_CONTROLLER_PORT = 0;
-    public static final int ELEVATOR_PRIMARY_MOTOR_ID = 1;
+    public static final int DRIVER_CONTROLLER_PORT      = 0;
+    public static final int OPERATOR_CONTROLLER_PORT    = 1;
+
+    public static final int ELEVATOR_PRIMARY_MOTOR_ID   = 1;
     public static final int ELEVATOR_SECONDARY_MOTOR_ID = 2;
+
+    public static final int MAILBOX_OUTPUT_BUTTON = XboxMappings.Button.A;
+    public static final int MAILBOX_INPUT_BUTTON  = XboxMappings.Button.B;
+    public static final int MAILBOX_STOP_BUTTON   = XboxMappings.Button.X;
 }

--- a/src/main/java/frc/robot/subsystems/mailbox/MailboxSubststem.java
+++ b/src/main/java/frc/robot/subsystems/mailbox/MailboxSubststem.java
@@ -1,0 +1,45 @@
+package frc.robot.subsystems.mailbox;
+
+import com.ctre.phoenix.motorcontrol.ControlMode;
+import com.ctre.phoenix.motorcontrol.can.TalonSRX;
+
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.robot.constants.MailboxConstants;
+
+public class MailboxSubststem extends SubsystemBase {
+    private final TalonSRX[] motors;
+
+    public MailboxSubststem() {
+        this.motors = new TalonSRX[2];
+        this.motors[0] = new TalonSRX(MailboxConstants.MOTOR_ONE_ID);
+        this.motors[2] = new TalonSRX(MailboxConstants.MOTOR_TWO_ID);
+        SmartDashboard.putString("[MAILBOX] State", "Unknown");
+    }
+
+    public MailboxSubststem(int motorOneId, int motorTwoId) {
+        this.motors = new TalonSRX[2];
+        this.motors[0] = new TalonSRX(motorOneId);
+        this.motors[2] = new TalonSRX(motorTwoId);
+        SmartDashboard.putString("[MAILBOX] State", "Unknown");
+    }
+
+    public void input() {
+        this.motors[0].set(ControlMode.PercentOutput, MailboxConstants.INPUT_MOTOR_ONE_SPEED);
+        this.motors[1].set(ControlMode.PercentOutput, MailboxConstants.INPUT_MOTOR_TWO_SPEED);
+        SmartDashboard.putString("[MAILBOX] State", "Input");
+    }
+
+    public void output() {
+        // This will need limit switches or other timings to tell when output is complete
+        this.motors[0].set(ControlMode.PercentOutput, MailboxConstants.OUTPUT_MOTOR_SPEED);
+        this.motors[1].set(ControlMode.PercentOutput, MailboxConstants.OUTPUT_MOTOR_SPEED);
+        SmartDashboard.putString("[MAILBOX] State", "Output");
+    }
+
+    public void stop() {
+        this.motors[0].set(ControlMode.PercentOutput, 0);
+        this.motors[1].set(ControlMode.PercentOutput, 0);
+        SmartDashboard.putString("[MAILBOX] State", "Stopped");
+    }
+}

--- a/src/main/java/frc/robot/subsystems/mailbox/MailboxSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/mailbox/MailboxSubsystem.java
@@ -7,20 +7,20 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.constants.MailboxConstants;
 
-public class MailboxSubststem extends SubsystemBase {
+public class MailboxSubsystem extends SubsystemBase {
     private final TalonSRX[] motors;
 
-    public MailboxSubststem() {
+    public MailboxSubsystem() {
         this.motors = new TalonSRX[2];
         this.motors[0] = new TalonSRX(MailboxConstants.MOTOR_ONE_ID);
-        this.motors[2] = new TalonSRX(MailboxConstants.MOTOR_TWO_ID);
+        this.motors[1] = new TalonSRX(MailboxConstants.MOTOR_TWO_ID);
         SmartDashboard.putString("[MAILBOX] State", "Unknown");
     }
 
-    public MailboxSubststem(int motorOneId, int motorTwoId) {
+    public MailboxSubsystem(int motorOneId, int motorTwoId) {
         this.motors = new TalonSRX[2];
         this.motors[0] = new TalonSRX(motorOneId);
-        this.motors[2] = new TalonSRX(motorTwoId);
+        this.motors[1] = new TalonSRX(motorTwoId);
         SmartDashboard.putString("[MAILBOX] State", "Unknown");
     }
 
@@ -41,5 +41,11 @@ public class MailboxSubststem extends SubsystemBase {
         this.motors[0].set(ControlMode.PercentOutput, 0);
         this.motors[1].set(ControlMode.PercentOutput, 0);
         SmartDashboard.putString("[MAILBOX] State", "Stopped");
+    }
+
+    @Override
+    public void periodic() {
+        SmartDashboard.putNumber("[MAILBOX] Motor One Speed", this.motors[0].getMotorOutputPercent());
+        SmartDashboard.putNumber("[MAILBOX] Motor Two Speed", this.motors[1].getMotorOutputPercent());
     }
 }


### PR DESCRIPTION
This contains the code to output and input from a theoretical mailbox.
As of now, the user will click a button to set the mailbox into input mode, output mode, or to stop it.
The simulation showed the motors successfully moving at their requested speeds when the mailbox commands were executed.
This branch also contains mappings for Xbox buttons, triggers, and D-pad angles.